### PR TITLE
feat: extend spec parsing with STATUS/UPDATED, ArchitectureReferences and Risks

### DIFF
--- a/src/Orchestrator.App/Core/Models/ParsedSpec.cs
+++ b/src/Orchestrator.App/Core/Models/ParsedSpec.cs
@@ -3,6 +3,10 @@ namespace Orchestrator.App.Core.Models;
 public sealed record ParsedSpec(
     string Goal,
     string NonGoals,
+    string Status,
+    DateTime? Updated,
+    IReadOnlyList<string> ArchitectureReferences,
+    IReadOnlyList<string> Risks,
     IReadOnlyList<string> Components,
     IReadOnlyList<TouchListEntry> TouchList,
     IReadOnlyList<string> Interfaces,

--- a/tests/Core/CoreModelsTests.cs
+++ b/tests/Core/CoreModelsTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using CoreModels = Orchestrator.App.Core.Models;
 using Xunit;
@@ -94,6 +95,10 @@ public class CoreModelsTests
         var spec = new CoreModels.ParsedSpec(
             Goal: "Ship feature",
             NonGoals: "No redesign",
+            Status: "Draft",
+            Updated: new DateTime(2024, 1, 12),
+            ArchitectureReferences: new List<string> { "ADR-1" },
+            Risks: new List<string> { "Risk-1" },
             Components: new List<string> { "API" },
             TouchList: touchList,
             Interfaces: new List<string> { "IService" },
@@ -105,6 +110,10 @@ public class CoreModelsTests
 
         Assert.Equal("Ship feature", spec.Goal);
         Assert.Equal("No redesign", spec.NonGoals);
+        Assert.Equal("Draft", spec.Status);
+        Assert.Equal(new DateTime(2024, 1, 12), spec.Updated);
+        Assert.Equal("ADR-1", spec.ArchitectureReferences[0]);
+        Assert.Equal("Risk-1", spec.Risks[0]);
         Assert.Equal("API", spec.Components[0]);
         Assert.Equal(touchList, spec.TouchList);
         Assert.Equal("IService", spec.Interfaces[0]);

--- a/tests/Parsing/SpecParserTests.cs
+++ b/tests/Parsing/SpecParserTests.cs
@@ -1,3 +1,4 @@
+using System;
 using FluentAssertions;
 using Orchestrator.App.Core.Models;
 using Orchestrator.App.Parsing;
@@ -12,6 +13,8 @@ public class SpecParserTests
     {
         var parser = new SpecParser();
         var input = @"# Spec: Test
+STATUS: Draft
+UPDATED: 2024-02-10
 
 ## Goal
 Make it work.
@@ -32,6 +35,15 @@ Don't break it.
 ```csharp
 interface ITest {}
 ```
+
+## Architektur-Referenzen
+- ADR-001
+- docs/architecture.md
+
+## Risiken
+| Risiko | Beschreibung |
+|--------|--------------|
+| R1 | Timebox |
 
 ## Scenarios
 Scenario: A
@@ -58,6 +70,10 @@ Scenario: B
 
         result.Goal.Should().Be("Make it work.");
         result.NonGoals.Should().Be("Don't break it.");
+        result.Status.Should().Be("Draft");
+        result.Updated.Should().Be(new DateTime(2024, 2, 10));
+        result.ArchitectureReferences.Should().HaveCount(2).And.Contain("ADR-001");
+        result.Risks.Should().HaveCount(1);
         result.Components.Should().HaveCount(2).And.Contain("Core");
         result.TouchList.Should().HaveCount(1);
         result.TouchList[0].Path.Should().Be("src/A.cs");
@@ -65,5 +81,23 @@ Scenario: B
         result.Scenarios.Should().HaveCount(2);
         result.Sequence.Should().HaveCount(2);
         result.TestMatrix.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void Parse_SpecWithoutOptionalSections_ReturnsEmptyValues()
+    {
+        var parser = new SpecParser();
+        var input = @"# Spec: Test
+
+## Goal
+Make it work.
+";
+
+        var result = parser.Parse(input);
+
+        result.Status.Should().BeEmpty();
+        result.Updated.Should().BeNull();
+        result.ArchitectureReferences.Should().BeEmpty();
+        result.Risks.Should().BeEmpty();
     }
 }


### PR DESCRIPTION
### Motivation
- Specs may include top-level metadata (`STATUS`, `UPDATED`) and new sections for architecture references and risks that should be accessible in the parsed model.  
- The existing parsed model lacked fields for status, update timestamp, architecture references and risk entries.  
- Tests should validate the new metadata handling and the behavior when optional sections are absent.

### Description
- Added new properties to the `ParsedSpec` record: `Status`, `Updated`, `ArchitectureReferences`, and `Risks` in `src/Orchestrator.App/Core/Models/ParsedSpec.cs`.  
- Extended `SpecParser` to read top-level headers via `GetTopLevelHeaderValue`/`GetTopLevelContent`, to parse `UPDATED` into a `DateTime?` using `ParseUpdated`, and to extract `Architektur-Referenzen`/`Risiken` sections (with table support) using `ParseList` / `ParseRisks` in `src/Orchestrator.App/Parsing/SpecParser.cs`.  
- Updated and added xUnit tests to cover the new fields and optional-section behavior in `tests/Parsing/SpecParserTests.cs` and adjusted model tests in `tests/Core/CoreModelsTests.cs`.

### Testing
- Added/updated automated tests: `tests/Parsing/SpecParserTests.cs` (happy path + missing optional sections) and `tests/Core/CoreModelsTests.cs`.  
- No test runs were executed as part of this change; to run tests locally use `dotnet test tests/Orchestrator.App.Tests.csproj --configuration Release` or the repo-provided `dotnet test` command.  
- Manual verification: code compiles locally in the patch context but automated test results were not produced in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e5046949883288d443bb273ad09ae)