### PR TITLE
fix: expand gherkin validation

### DIFF
--- a/tests/Parsing/GherkinValidatorTests.cs
+++ b/tests/Parsing/GherkinValidatorTests.cs
@@ -25,9 +25,41 @@ Scenario: Test
         var validator = new GherkinValidator();
         var input = @"
 Scenario: Test
-  Given context
+  And context
 ";
         validator.IsValid(input).Should().BeFalse();
+    }
+
+    [Fact]
+    public void IsValid_CodeFenceScenario_ReturnsTrue()
+    {
+        var validator = new GherkinValidator();
+        var input = @"
+```gherkin
+Scenario: Test
+  Given context
+  When action
+  Then result
+```
+";
+        validator.IsValid(input).Should().BeTrue();
+    }
+
+    [Fact]
+    public void IsValid_OutlineScenario_ReturnsTrue()
+    {
+        var validator = new GherkinValidator();
+        var input = @"
+Scenario Outline: Example
+  Given <state>
+  When action
+  Then result
+
+Examples:
+  | state |
+  | ready |
+";
+        validator.IsValid(input).Should().BeTrue();
     }
 
     [Fact]


### PR DESCRIPTION
### Motivation
- Strip fenced code blocks before validation so Gherkin pasted inside triple-backticks is handled correctly.
- Accept `Scenario Outline:` and `Background:` as valid scenario headers to cover common Gherkin variants.
- Require at least one primary step (`Given`/`When`/`Then`) across the scenario rather than enforcing all three.

### Description
- Import `Orchestrator.App.Utilities` and apply `CodeHelpers.StripCodeFence` to normalize input before parsing.
- Treat `Scenario:`, `Scenario Outline:`, and `Background:` as scenario headers and detect `Given`/`When`/`Then` as primary steps.
- Replace the previous multi-flag logic with `hasScenarioHeader` and `hasPrimaryStep` and return their conjunction as the validation result.
- Add unit tests in `tests/Parsing/GherkinValidatorTests.cs` for code-fenced input and scenario outlines, and update the missing-keyword test to assert failure when only `And` is present.

### Testing
- Added xUnit tests: `IsValid_CodeFenceScenario_ReturnsTrue` and `IsValid_OutlineScenario_ReturnsTrue`, and updated existing tests in `tests/Parsing/GherkinValidatorTests.cs`.
- No automated test run was performed as part of this change.
- To run the test suite locally execute `dotnet test tests/Orchestrator.App.Tests.csproj --configuration Release`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e536be1b8832889365b3556f1b72f)