### PR TITLE
fix: Clean working tree before branch checkout to prevent conflicts

### DIFF
--- a/src/Orchestrator.App/Infrastructure/Git/RepoGit.cs
+++ b/src/Orchestrator.App/Infrastructure/Git/RepoGit.cs
@@ -89,6 +89,10 @@ internal sealed class RepoGit : IRepoGit
 
         MoveUntrackedGeneratedFiles();
 
+        // Clean working tree before checkout to prevent conflicts
+        repo.Reset(ResetMode.Hard);
+        repo.RemoveUntrackedFiles();
+
         // Check if remote branch exists
         var remoteBranchName = $"origin/{branchName}";
         var remoteBranch = repo.Branches[remoteBranchName];


### PR DESCRIPTION
## Problems Fixed

### 1. ContextBuilder: Branch checkout conflicts

**Error:**
```
[ERROR] [ContextBuilder] Git error creating branch: 1 conflict prevents checkout
```

**Root Cause:** Working tree had modified files that conflicted with target branch checkout.

**Fix:** Added hard reset + clean before checkout in `RepoGit.EnsureBranch()`:
```csharp
MoveUntrackedGeneratedFiles();  // Backup orchestrator files
repo.Reset(ResetMode.Hard);     // Discard local changes
repo.RemoveUntrackedFiles();    // Clean untracked files
// ... then checkout
```

### 2. Refinement: Directory creation failure

**Error:**
```
[ERROR] Failed to create directory: orchestrator/refinement
Error: Parent directory does not exist: /workspace/orchestrator
```

**Root Cause:** `McpFileOperations.EnsureDirectoryExistsAsync()` was NOT recursive. When creating `orchestrator/refinement`, MCP `create_directory` failed because parent `orchestrator/` didn't exist.

**Fix:** Made `EnsureDirectoryExistsAsync` recursive (like `mkdir -p`):
```csharp
// First ensure parent exists (recursive)
var parent = Path.GetDirectoryName(path);
if (!string.IsNullOrWhiteSpace(parent)) {
    await EnsureDirectoryExistsAsync(parent);
}
// Then create this directory
await _mcpManager.CallToolAsync("create_directory", args);
```

### 3. Refinement: Infinite question loop

**Error:**
```
[INFO] Refinement complete: 4 criteria, 2 questions
[INFO] Refinement complete: 4 criteria, 2 questions (again!)
[INFO] Refinement complete: 4 criteria, 2 questions (again!!)
[ERROR] Iteration limit reached for QuestionClassifier (4/3)
```

**Root Cause:** After TechnicalAdvisor answered questions, Refinement generated NEW questions (paraphrases of old ones) instead of accepting answers:
- Q#2: "Is IGitHubClient public API?"
- Q#5: "Is IGitHubClient public API with deprecation?" ← Paraphrase!
- Q#7: "Is IGitHubClient public API? Provide package..." ← Paraphrase!!

The LLM kept inventing new/paraphrased questions → infinite loop → iteration limit.

**Fix:** Made RefinementPrompt context-aware based on `answeredQuestions`:

**First iteration (no answers yet):**
```
System Prompt: "5. MAX 3-5 QUESTIONS: Only ask essential questions"
```

**After answers incorporated:**
```
System Prompt: "5. AFTER INCORPORATING ANSWERS: Return ZERO open questions"
User Prompt:   "Return openQuestions: [] (empty array) in your JSON response"
```

This prevents the loop: Refinement → Questions → Answers → **No New Questions** → DoR

## Why These Fixes Are Safe

**Fix 1 (Hard Reset):**
- Orchestrator-generated files are backed up first by `MoveUntrackedGeneratedFiles()`
- Workflow always creates branches from remote, so local changes are intentional discards

**Fix 2 (Recursive mkdir):**
- Standard Unix `mkdir -p` behavior
- Directories created in correct parent→child order

**Fix 3 (Context-Aware Prompts):**
- First iteration behavior unchanged (can ask 3-5 questions)
- Only changes behavior AFTER answers incorporated (prevent re-asking)
- Tests verify new prompt structure

## Testing

- ✅ All 279 tests pass
- ✅ Updated RefinementPromptTests to verify context-aware behavior
- ✅ No breaking changes to existing workflows

## Files Changed

- `src/Orchestrator.App/Infrastructure/Git/RepoGit.cs` (+4 lines)
  - Added hard reset and clean before checkout
  
- `src/Orchestrator.App/Infrastructure/Mcp/McpFileOperations.cs` (+14 lines, -1 line)
  - Made EnsureDirectoryExistsAsync recursive

- `src/Orchestrator.App/Workflows/Prompts/RefinementPrompt.cs` (+18 lines, -8 lines)
  - Context-aware system prompt based on answeredQuestions
  - Explicit "Return openQuestions: []" instruction after answers
  
- `tests/Workflows/RefinementPromptTests.cs` (+5 lines, -3 lines)
  - Updated test to verify new context-aware behavior

## Impact

Issue #42 and #43 workflows can now:
1. ✅ Create branches without conflicts
2. ✅ Create nested directories (orchestrator/refinement/)
3. ✅ Answer questions without infinite loop
4. ✅ Proceed to DoR after questions answered